### PR TITLE
[Style] Footer 링크 연결 & 캐러셀 반응형 수정

### DIFF
--- a/apps/landing/src/components/carousel-card.tsx
+++ b/apps/landing/src/components/carousel-card.tsx
@@ -38,7 +38,7 @@ function CarouselCard({
 }: CarouselCardProps) {
   return (
     <div className="flex h-full items-center justify-center tablet:w-[480px] tablet:px-[15px] pc:w-[480px] pc:px-[15px] mobile:h-[167px] mobile:w-[200px]">
-      <div className="group-card h-[347px] w-[450px] overflow-hidden rounded-[20px] shadow-suldak-card  mobile:h-[167px] mobile:rounded-[12px] mobile:w-[200px] mobile:px-[16px] mobile:py-[20px] tablet:p-[40px] pc:p-[40px]">
+      <div className="group-card h-[347px] w-[450px] overflow-hidden rounded-[20px] shadow-suldak-card  mobile:h-[167px] mobile:rounded-[15px] mobile:w-[200px] mobile:px-[16px] mobile:py-[20px] tablet:p-[40px] pc:p-[40px]">
         <div className="tags flex gap-x-[12px] mobile:gap-x-[6px]">
           {tags.map((tag, index) => (
             <HashTag key={index} content={tag.content} color={tag.color} />

--- a/apps/landing/src/components/carousel-card.tsx
+++ b/apps/landing/src/components/carousel-card.tsx
@@ -37,7 +37,7 @@ function CarouselCard({
   ProfilePics,
 }: CarouselCardProps) {
   return (
-    <div className="flex h-full items-center justify-center tablet:w-[480px] tablet:px-[15px] pc:w-[480px] pc:px-[15px]">
+    <div className="flex h-full items-center justify-center tablet:w-[480px] tablet:px-[15px] pc:w-[480px] pc:px-[15px] mobile:h-[167px] mobile:w-[200px]">
       <div className="group-card h-[347px] w-[450px] overflow-hidden rounded-[20px] shadow-suldak-card  mobile:h-[167px] mobile:w-[200px] mobile:px-[16px] mobile:py-[20px] tablet:p-[40px] pc:p-[40px]">
         <div className="tags flex gap-x-[12px] mobile:gap-x-[6px]">
           {tags.map((tag, index) => (
@@ -55,7 +55,10 @@ function CarouselCard({
         </div>
         <div className="mt-[26px] flex items-center mobile:mt-[18px]">
           {ProfilePics.map((pic, index) => (
-            <div key={index} className="relative h-[72px] w-[72px] mobile:h-[32px] mobile:w-[32px]">
+            <div
+              key={index}
+              className="relative h-[72px] w-[72px] mobile:h-[32px] mobile:w-[32px]"
+            >
               <Image src={pic.src} alt={pic.alt} fill quality={100} />
             </div>
           ))}

--- a/apps/landing/src/components/carousel-card.tsx
+++ b/apps/landing/src/components/carousel-card.tsx
@@ -38,7 +38,7 @@ function CarouselCard({
 }: CarouselCardProps) {
   return (
     <div className="flex h-full items-center justify-center tablet:w-[480px] tablet:px-[15px] pc:w-[480px] pc:px-[15px] mobile:h-[167px] mobile:w-[200px]">
-      <div className="group-card h-[347px] w-[450px] overflow-hidden rounded-[20px] shadow-suldak-card  mobile:h-[167px] mobile:w-[200px] mobile:px-[16px] mobile:py-[20px] tablet:p-[40px] pc:p-[40px]">
+      <div className="group-card h-[347px] w-[450px] overflow-hidden rounded-[20px] shadow-suldak-card  mobile:h-[167px] mobile:rounded-[12px] mobile:w-[200px] mobile:px-[16px] mobile:py-[20px] tablet:p-[40px] pc:p-[40px]">
         <div className="tags flex gap-x-[12px] mobile:gap-x-[6px]">
           {tags.map((tag, index) => (
             <HashTag key={index} content={tag.content} color={tag.color} />

--- a/apps/landing/src/components/footer.tsx
+++ b/apps/landing/src/components/footer.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import React from 'react';
 
 interface FooterProps {
@@ -15,15 +16,39 @@ const Footer: React.ForwardRefRenderFunction<HTMLDivElement, FooterProps> = (
     >
       <div className="flex-col h-[100px]">
         <div className="flex items-center">
-          <div>푸터 메뉴</div>
+          <Link
+            href="https://suldak.notion.site/8c83b32c990b4cbf9d34ad8944214284"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            이용약관
+          </Link>
           <div className="mx-2 w-[1px] h-[8px] mobile:h-[10px] bg-white opacity-50"></div>
-          <div>푸터 메뉴</div>
+          <Link
+            href="https://suldak.notion.site/6993e29d3a7d4625ab12fc2807cd712b"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            개인정보 처리방침
+          </Link>
           <div className="mx-2 w-[1px] h-[8px] mobile:h-[10px] bg-white opacity-50"></div>
-          <div>푸터 메뉴</div>
+          <Link
+            href="https://www.instagram.com/suldak.official/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            인스타그램
+          </Link>
           <div className="mx-2 w-[1px] h-[8px] mobile:h-[10px] bg-white opacity-50"></div>
-          <div>푸터 메뉴</div>
+          <Link
+            href="https://suldak.tistory.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            블로그
+          </Link>
           <div className="mx-2 w-[1px] h-[8px] mobile:h-[10px] bg-white opacity-50"></div>
-          <div>푸터 메뉴</div>
+          <a href="mailto:suldak.official@gmail.com">Contact</a>
         </div>
         <div>Copyright © 술닥술닥 all rights reserved</div>
       </div>
@@ -32,4 +57,3 @@ const Footer: React.ForwardRefRenderFunction<HTMLDivElement, FooterProps> = (
 };
 
 export default React.forwardRef(Footer);
-

--- a/apps/landing/src/components/group-carousel.tsx
+++ b/apps/landing/src/components/group-carousel.tsx
@@ -79,17 +79,24 @@ function GroupCarousel() {
   };
   return (
     <section className="flex relative mobile:mt-[40px] mt-[64px] w-full bg-white ">
-      {' '}
-      <div className="flex carousel-container w-full max-w-[2100px] overflow-x-hidden">
-        {' '}
+      <div className="flex carousel-container mobile:hidden w-screen max-w-[2100px] overflow-x-hidden">
         <InfiniteCarousel
           items={renderCarouselItems()}
-          speed={2}
+          speed={2.25}
           direction="left"
           itemWidth={480}
           itemHeight={380}
-        />{' '}
-      </div>{' '}
+        />
+      </div>
+      <div className="flex carousel-container tablet:hidden pc:hidden w-screen max-w-[2100px] overflow-x-hidden">
+        <InfiniteCarousel
+          items={renderCarouselItems()}
+          speed={2.25}
+          direction="left"
+          itemWidth={210}
+          itemHeight={188}
+        />
+      </div>
     </section>
   );
 }

--- a/apps/landing/src/components/group-carousel.tsx
+++ b/apps/landing/src/components/group-carousel.tsx
@@ -82,7 +82,7 @@ function GroupCarousel() {
       <div className="flex carousel-container mobile:hidden w-screen max-w-[2100px] overflow-x-hidden">
         <InfiniteCarousel
           items={renderCarouselItems()}
-          speed={2.25}
+          speed={4}
           direction="left"
           itemWidth={480}
           itemHeight={380}

--- a/apps/landing/src/components/group-carousel.tsx
+++ b/apps/landing/src/components/group-carousel.tsx
@@ -80,7 +80,7 @@ function GroupCarousel() {
   return (
     <section className="flex relative mt-[64px] w-full bg-white mobile:mt-[40px]">
       {' '}
-      <div className="flex carousel-container w-full max-w-[1890px] overflow-x-hidden">
+      <div className="flex carousel-container w-full max-w-[2100px] overflow-x-hidden">
         {' '}
         <InfiniteCarousel
           items={renderCarouselItems()}

--- a/apps/landing/src/components/group-carousel.tsx
+++ b/apps/landing/src/components/group-carousel.tsx
@@ -78,7 +78,7 @@ function GroupCarousel() {
     ));
   };
   return (
-    <section className="flex relative mt-[64px] w-full bg-white mobile:mt-[40px]">
+    <section className="flex relative mobile:mt-[40px] mt-[64px] w-full bg-white ">
       {' '}
       <div className="flex carousel-container w-full max-w-[2100px] overflow-x-hidden">
         {' '}

--- a/apps/landing/src/components/group-section.tsx
+++ b/apps/landing/src/components/group-section.tsx
@@ -3,8 +3,8 @@ import GroupCarousel from '@components/group-carousel';
 
 function GroupSection() {
   return (
-    <section className="flex h-[920px] w-full flex-col py-[184px] text-suldak-gray-900 mobile:h-[443px] mobile:py-[60px] mobile:text-center tablet:text-center ">
-      <div className="flex mobile:w-full h-[142px] w-[390px] flex-col text-[32px] mobile:justify-center mobile:text-[22px] tablet:w-full tablet:justify-center pc:ml-[18%] pc:w-[309px]">
+    <section className="flex h-[920px] w-full flex-col tablet:py-[184px] pc:py-[184px] text-suldak-gray-900 mobile:h-[443px] mobile:pt-[60px] mobile:text-center tablet:text-center">
+      <div className="flex mobile:w-full h-[142px] mobile:h-[116px] w-[390px] flex-col text-[32px] mobile:text-[22px] tablet:w-full tablet:justify-center pc:ml-[18%] pc:w-[309px]">
         <div className="flex flex-col font-bold mobile:items-center tablet:items-center">
           <div className="mobile:mb-[8px] tablet:mb-[8px]">
             <TalkImg />

--- a/apps/landing/src/components/group-section.tsx
+++ b/apps/landing/src/components/group-section.tsx
@@ -3,7 +3,7 @@ import GroupCarousel from '@components/group-carousel';
 
 function GroupSection() {
   return (
-    <section className="flex h-[920px] w-full flex-col py-[184px] text-suldak-gray-900 mobile:h-[443px] mobile:py-[60px] mobile:text-center tablet:text-center pc:pr-[215px]">
+    <section className="flex h-[920px] w-full flex-col py-[184px] text-suldak-gray-900 mobile:h-[443px] mobile:py-[60px] mobile:text-center tablet:text-center ">
       <div className="flex mobile:w-full h-[142px] w-[390px] flex-col text-[32px] mobile:justify-center mobile:text-[22px] tablet:w-full tablet:justify-center pc:ml-[18%] pc:w-[309px]">
         <div className="flex flex-col font-bold mobile:items-center tablet:items-center">
           <div className="mobile:mb-[8px] tablet:mb-[8px]">

--- a/apps/landing/src/components/infinite-carousel.tsx
+++ b/apps/landing/src/components/infinite-carousel.tsx
@@ -49,7 +49,7 @@ function InfiniteCarousel({
   const renderItems = () => {
     return items.concat(items).map((item, index) => (
       <div
-        className="relative inline-block shrink-0 mr-[8px]"
+        className="flex bg-white relative items-center shrink-0 mr-[20px] mobile:mr-[10px]"
         key={index}
         style={{ width: `${itemWidth}px`, height: `${itemHeight}px` }}
       >

--- a/apps/landing/src/components/infinite-carousel.tsx
+++ b/apps/landing/src/components/infinite-carousel.tsx
@@ -49,17 +49,16 @@ function InfiniteCarousel({
   const renderItems = () => {
     return items.concat(items).map((item, index) => (
       <div
-        className="inline-block shrink-0 mr-[8px]"
+        className="relative inline-block shrink-0 mr-[8px]"
         key={index}
         style={{ width: `${itemWidth}px`, height: `${itemHeight}px` }}
       >
         {typeof item === 'string' || isStaticImageData(item) ? (
           <Image
             alt={`Carousel item ${index + 1}`}
-            height={itemHeight}
-            objectFit="cover"
+            fill
             src={item}
-            width={itemWidth}
+            className="relative"
           />
         ) : (
           item

--- a/apps/landing/src/components/review-carousel.tsx
+++ b/apps/landing/src/components/review-carousel.tsx
@@ -27,26 +27,48 @@ function ReviewCarousel() {
   ];
 
   return (
-    <div className="space-y-[8px] overflow-hidden pc:space-y-[20px]">
-      <div className="pl-[20px]">
-        <InfiniteCarousel
-          items={topImages}
-          speed={2}
-          direction="left"
-          itemWidth={416}
-          itemHeight={250}
-        />
+    <>
+      <div className="mobile:hidden overflow-hidden space-y-[20px]">
+        <div className="pl-[20px]">
+          <InfiniteCarousel
+            items={topImages}
+            speed={2}
+            direction="left"
+            itemWidth={416}
+            itemHeight={250}
+          />
+        </div>
+        <div className="pr-[20px]">
+          <InfiniteCarousel
+            items={bottomImages}
+            speed={2}
+            direction="right"
+            itemWidth={416}
+            itemHeight={250}
+          />
+        </div>
       </div>
-      <div className="pr-[20px]">
-        <InfiniteCarousel
-          items={bottomImages}
-          speed={2}
-          direction="right"
-          itemWidth={416}
-          itemHeight={250}
-        />
+      <div className="tablet:hidden pc:hidden overflow-hidden space-y-[8px]">
+        <div className="pl-[8px]">
+          <InfiniteCarousel
+            items={topImages}
+            speed={2}
+            direction="left"
+            itemWidth={168}
+            itemHeight={120}
+          />
+        </div>
+        <div className="pr-[8px]">
+          <InfiniteCarousel
+            items={bottomImages}
+            speed={2}
+            direction="right"
+            itemWidth={168}
+            itemHeight={120}
+          />
+        </div>
       </div>
-    </div>
+    </>
   );
 }
 

--- a/apps/landing/src/components/review-carousel.tsx
+++ b/apps/landing/src/components/review-carousel.tsx
@@ -32,7 +32,7 @@ function ReviewCarousel() {
         <div className="pl-[20px]">
           <InfiniteCarousel
             items={topImages}
-            speed={2}
+            speed={2.5}
             direction="left"
             itemWidth={416}
             itemHeight={250}
@@ -41,7 +41,7 @@ function ReviewCarousel() {
         <div className="pr-[20px]">
           <InfiniteCarousel
             items={bottomImages}
-            speed={2}
+            speed={2.5}
             direction="right"
             itemWidth={416}
             itemHeight={250}

--- a/apps/landing/src/components/review-carousel.tsx
+++ b/apps/landing/src/components/review-carousel.tsx
@@ -32,7 +32,7 @@ function ReviewCarousel() {
         <div className="pl-[20px]">
           <InfiniteCarousel
             items={topImages}
-            speed={2.5}
+            speed={4}
             direction="left"
             itemWidth={416}
             itemHeight={250}

--- a/packages/config-tailwind/tailwind.config.ts
+++ b/packages/config-tailwind/tailwind.config.ts
@@ -23,7 +23,7 @@ const config: Omit<Config, 'content'> = {
         'suldak-mint-200': '#9CE5EA',
       },
       boxShadow: {
-        'suldak-card': '2px 2px 20px -3px rgba(0, 0, 0, 0.13)',
+        'suldak-card': '2px 2px 14px -3px rgba(0, 0, 0, 0.13)',
       },
       padding: {
         '18px': '18px',


### PR DESCRIPTION
## 스크린샷
<img width="446" alt="스크린샷 2024-10-16 오전 3 07 05" src="https://github.com/user-attachments/assets/e8612ea6-fdb7-49d0-aab7-ee0d1bf0aaa8">

## 구현사항
- [X] 푸터에 실제 링크들을 연결했습니다. 클릭 시 다른 탭에서 연결되도록 했습니다. 
- [X] 캐러셀 반응형 스타일링을 수정했습니다. 불필요한 여백을 삭제하고, box-shadow를 피그마에 맞추고 캐러셀의 속도를 변경하였습니다.