### PR TITLE
[Fix] 일부 디바이스에서 사전예약 버튼 클릭 시 사전예약 섹션으로 이동되지 않는 현상 해결

### DIFF
--- a/apps/landing/src/app/page.tsx
+++ b/apps/landing/src/app/page.tsx
@@ -1,25 +1,31 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import ServiceSection from '@components/service-section';
-import CopySection from '@components/copy-section';
-import GroupSection from '@components/group-section';
-import Header from '@components/header';
-import NavigationBar from '@components/navigation-bar';
-import ReservationSection from '@components/reservation-section';
-import ReviewSection from '@components/review-section';
-import Footer from '@components/footer';
+import { scrollToElement, getElementHeight } from '@utils/scroll';
+import ServiceSection from '@/components/service-section';
+import CopySection from '@/components/copy-section';
+import GroupSection from '@/components/group-section';
+import Header from '@/components/header';
+import NavigationBar from '@/components/navigation-bar';
+import ReservationSection from '@/components/reservation-section';
+import ReviewSection from '@/components/review-section';
+import Footer from '@/components/footer';
 
-function LandingPage() {
-  const [isMounted, setIsMounted] = useState(false);
-  const reservationRef = useRef<HTMLDivElement>(null);
+type ScrollHandler = () => void;
+
+const LandingPage = (): JSX.Element | null => {
+  const [isMounted, setIsMounted] = useState<boolean>(false);
+  const reservationRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     setIsMounted(true);
   }, []);
 
-  const scrollToReservation = () => {
-    reservationRef.current?.scrollIntoView({ behavior: 'smooth' });
+  const scrollToReservation: ScrollHandler = () => {
+    if (typeof window === 'undefined') return;
+
+    const navigationBarHeight = getElementHeight('.navigation-bar');
+    scrollToElement(reservationRef.current, navigationBarHeight);
   };
 
   if (!isMounted) {
@@ -38,6 +44,6 @@ function LandingPage() {
       <NavigationBar scrollToReservation={scrollToReservation} />
     </div>
   );
-}
+};
 
 export default LandingPage;

--- a/apps/landing/src/components/header.tsx
+++ b/apps/landing/src/components/header.tsx
@@ -1,50 +1,68 @@
 'use client';
 
 import Image from 'next/image';
-import HeadRight from '@assets/icons/ico-head-right.svg';
-import HeadImg from '@assets/images/image-head.png';
-import AnimationData from '@assets/images/animation-web-blog.json';
-import VectorImg from '@assets/images/img-vector.png';
 import dynamic from 'next/dynamic';
+import HeadRight from '@/assets/icons/ico-head-right.svg';
+import HeadImg from '@/assets/images/image-head.png';
+import AnimationData from '@/assets/images/animation-web-blog.json';
+import VectorImg from '@/assets/images/img-vector.png';
+
 interface HeaderProps {
   scrollToReservation: () => void;
 }
 
-const Lottie = dynamic(() => import('lottie-react'), { ssr: false });
+// Lottie 컴포넌트를 동적으로 불러오기
+const Lottie = dynamic(() => import('lottie-react'), {
+  ssr: false,
+  loading: () => <div className="w-[1000px] h-[474px]" />,
+});
 
-function Header({ scrollToReservation }: HeaderProps) {
+function Header({ scrollToReservation }: HeaderProps): JSX.Element {
   return (
     <>
       <div className="flex relative tablet:h-[800px] pc:h-[900px] mobile:h-[600px] w-full bg-suldak-mint-500">
         <div className="flex w-full relative justify-center items-center bg-suldak-mint-500">
+          {/* Desktop View Animation */}
           <div className="flex w-full tablet:hidden mobile:hidden justify-center items-center">
-            <div className="absolute bottom-0  justify-center items-center">
+            <div className="absolute bottom-0 justify-center items-center">
               <Image
                 src={VectorImg}
                 width={1100}
                 height={444}
-                alt="bg-vector"
+                alt="배경 벡터 이미지"
                 className="z-10"
+                priority
               />
             </div>
-            <div className="absolute z-20 bottom-4  justify-center items-center">
+            <div className="absolute z-20 bottom-4 justify-center items-center">
               <Lottie
                 animationData={AnimationData}
-                loop={true}
-                autoplay={true}
+                loop
+                autoplay
                 style={{ width: '1000px', height: '474px' }}
               />
             </div>
           </div>
+
+          {/* Tablet View Image */}
           <div className="absolute justify-center items-center bottom-0 pc:hidden mobile:hidden">
-            <Image src={HeadImg} alt="Header Image" height={743} width={600} />
+            <Image
+              src={HeadImg}
+              alt="태블릿용 헤더 이미지"
+              height={743}
+              width={600}
+              priority
+            />
           </div>
+
+          {/* Mobile View Image */}
           <div className="absolute justify-center items-center bottom-0 pc:hidden tablet:hidden">
             <Image
               src={HeadImg}
-              alt="Header Small Image"
+              alt="모바일용 헤더 이미지"
               height={288}
               width={355}
+              priority
             />
           </div>
         </div>
@@ -63,6 +81,7 @@ function Header({ scrollToReservation }: HeaderProps) {
           당신의 취향을 술닥술닥에서 만나보세요.
         </div>
         <button
+          type="button"
           className="mx-auto flex items-center rounded-full bg-white px-[20px] py-[16px] font-bold text-suldak-mint-500"
           onClick={scrollToReservation}
         >

--- a/apps/landing/src/components/header.tsx
+++ b/apps/landing/src/components/header.tsx
@@ -12,10 +12,7 @@ interface HeaderProps {
 }
 
 // Lottie 컴포넌트를 동적으로 불러오기
-const Lottie = dynamic(() => import('lottie-react'), {
-  ssr: false,
-  loading: () => <div className="w-[1000px] h-[474px]" />,
-});
+const Lottie = dynamic(() => import('lottie-react'), { ssr: false });
 
 function Header({ scrollToReservation }: HeaderProps): JSX.Element {
   return (

--- a/apps/landing/src/components/navigation-bar.tsx
+++ b/apps/landing/src/components/navigation-bar.tsx
@@ -9,6 +9,12 @@ interface NavigationProps {
 }
 
 function NavigationBar({ scrollToReservation }: NavigationProps) {
+  const handleBlogClick = () => {
+    if (typeof window !== 'undefined') {
+      window.open('https://suldak.tistory.com/', '_blank');
+    }
+  };
+
   return (
     <div className="fixed bottom-0 z-40 flex w-full justify-center">
       <div className="w-full pc:w-[62.5%] bg-white shadow-suldak-card mobile:rounded-t-[20px] pc:rounded-[12px] tablet:rounded-[12px]">
@@ -32,7 +38,10 @@ function NavigationBar({ scrollToReservation }: NavigationProps) {
                 <HeadRight className="ml-2" fill="white" />
               </button>
             ) : null}
-            <button className="flex items-center rounded-[30px] bg-suldak-mint-500 px-[20px] py-[10px] text-[16px] text-white mobile:hidden">
+            <button
+              className="flex items-center rounded-[30px] bg-suldak-mint-500 px-[20px] py-[10px] text-[16px] text-white mobile:hidden"
+              onClick={handleBlogClick}
+            >
               블로그 보기
               <HeadRight className="ml-2" fill="white" />
             </button>

--- a/apps/landing/tsconfig.json
+++ b/apps/landing/tsconfig.json
@@ -6,9 +6,16 @@
       "@/*": ["./src/*"],
       "@components/*": ["./src/components/*"],
       "@assets/*": ["./src/assets/*"],
-      "@apis/*": ["./apis/*"]
+      "@apis/*": ["./apis/*"],
+      "@utils/*": ["./utils/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "svg.d.ts"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    "svg.d.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/apps/landing/utils/scroll.ts
+++ b/apps/landing/utils/scroll.ts
@@ -1,0 +1,31 @@
+// utils/scroll.ts
+
+/**
+ * Scrolls to the specified element with an optional offset
+ * @param element - The target HTML element to scroll to
+ * @param offset - Optional offset from the top of the element
+ */
+export const scrollToElement = (
+  element: HTMLElement | null,
+  offset = 0,
+): void => {
+  if (!element) return;
+
+  const elementPosition = element.getBoundingClientRect().top;
+  const offsetPosition = elementPosition + window.scrollY - offset;
+
+  window.scrollTo({
+    top: offsetPosition,
+    behavior: 'smooth',
+  });
+};
+
+/**
+ * Gets the height of an element by class name
+ * @param className - The class name of the element
+ * @returns The height of the element or 0 if not found
+ */
+export const getElementHeight = (className: string): number => {
+  const element = document.querySelector(className);
+  return element ? element.getBoundingClientRect().height : 0;
+};

--- a/apps/landing/utils/scroll.ts
+++ b/apps/landing/utils/scroll.ts
@@ -1,9 +1,9 @@
 // utils/scroll.ts
 
 /**
- * Scrolls to the specified element with an optional offset
- * @param element - The target HTML element to scroll to
- * @param offset - Optional offset from the top of the element
+ * 옵셔널한 offset과 함께 특정 element로 이동
+ * @param element - 스크롤해서 이동할 타겟 html element
+ * @param offset - 옵셔널한 오프셋
  */
 export const scrollToElement = (
   element: HTMLElement | null,
@@ -21,9 +21,9 @@ export const scrollToElement = (
 };
 
 /**
- * Gets the height of an element by class name
- * @param className - The class name of the element
- * @returns The height of the element or 0 if not found
+   클래스네임으로 element의 height 가져옴
+ * @param className - element의 클래스네임
+ * @returns element height / 0(못 찾은 경우)
  */
 export const getElementHeight = (className: string): number => {
   const element = document.querySelector(className);


### PR DESCRIPTION
## 문제상황

https://github.com/user-attachments/assets/725e4ddd-4ae0-45ca-8542-83dda935936a

- 배포 후 팀원들 모두 폰에서는 제대로 작동한다고 하셨지만 몇몇 팀원이 pc에서 제대로 작동하지 않는다고 알려주셨습니다. (영상은 16인치 노트북에서 녹화했습니다) 

## 수정 후

https://github.com/user-attachments/assets/d07b0d12-7af5-442c-870f-cc972dfa15ec


- 가족의 16인치 노트북에서 실험해본 결과 suldak.me(배포화면)에서는 제대로 작동하지 않았지만 수정 후의 코드를 실행해보니 제대로 작동하는 것을 확인할 수 있었습니다.
## 해결
- 렌더링 후 useRef에 이동할 위치로 값이 초기화되기 전에 클릭해서 생기는 문제인가 의심했으나 수십초간 기다려도 작동하지 않는단 말을 들어서 이 가설은 폐기했습니다. 

- 그래서 scrollIntoView의 경우 fixed position의 네비게이션바 때문에 제대로 작동하지 않는다고 생각되었습니다. (참고: https://stackoverflow.com/questions/13614112/using-scrollintoview-with-a-fixed-position-header) scrollIntoView대신 scrollTo + offset을 사용해 보다 스크롤 위치를 정확히 계산하도록했습니다. window를 참조하기 때문에 클라이언트 사이드인지, window 가 undefined가 아닌지 확인하는 코드를 추가했습니다. NavigationBar가  fixed position이라 높이가 고려되지 않을 것을 생각해 NavigationBar 높이만큼을 빼도록했습니다. 

- 해결하며 블로그버튼 클릭 시 새 창을 열고 블로그로 이동하게 코드를 함께 변경했습니다. 